### PR TITLE
Keycloak's image changed from latest to 21.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:latest
+    image: quay.io/keycloak/keycloak:21.1
     entrypoint: ["/opt/keycloak/bin/kc.sh", "start-dev", "--import-realm"]
     volumes:
       - "./keycloak/data:/opt/keycloak/data"


### PR DESCRIPTION
I found there was some incompatibility with the latest version of Keycloak and Synapse. I tried a few different versions until I hit on 21.1 with no issues.